### PR TITLE
few enhancement/fixes to request context

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -98,17 +98,16 @@ describe('CLI', () => {
       expect(await cli.exitCode).toBe(0);
     });
 
-    it('provides an apiContext object for inline tests', async () => {
+    it('provides request context', async () => {
       const cli = new CLIMock()
         .stdin(
           `step('check body', async () => {
-          const resp = await apiContext.get(params.url);
+          const resp = await request.get(params.url);
           expect((await resp.body()).toString()).toMatch(/Synthetics/);
         })`
         )
         .args(['--inline', '--params', JSON.stringify(serverParams)])
         .run();
-      await cli.waitFor('Journey: inline');
       expect(await cli.exitCode).toBe(0);
     });
 
@@ -194,7 +193,7 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(1);
   });
 
-  it('runs a browser test with apiContext correctly', async () => {
+  it('runs a browser test with request correctly', async () => {
     const cli = new CLIMock(false)
       .args([
         join(FIXTURES_DIR, 'browser-with-api.journey.ts'),
@@ -202,8 +201,8 @@ describe('CLI', () => {
         JSON.stringify(serverParams),
       ])
       .run();
-    await cli.waitFor('Journey: browser with apicontext');
-    expect(cli.output()).toContain('browser with apicontext');
+    await cli.waitFor('Journey: browser with request');
+    expect(cli.output()).toContain('browser with request');
     expect(await cli.exitCode).toBe(0);
   });
 

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -230,10 +230,14 @@ describe('Gatherer', () => {
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });
+  });
 
-    it('provides an API context', async () => {
+  describe('API Request Context', () => {
+    it('exposes request', async () => {
       const driver = await Gatherer.setupDriver({ wsEndpoint });
-      expect(driver.apiContext).not.toBeNull();
+      expect(driver.request).not.toBeNull();
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
     });
   });
 });

--- a/__tests__/fixtures/browser-with-api.journey.ts
+++ b/__tests__/fixtures/browser-with-api.journey.ts
@@ -23,11 +23,11 @@
  *
  */
 
-import { journey, step, expect } from '../../src/index';
+import { journey, step, expect } from '../../';
 
-journey('browser with apicontext', ({ params, apiContext }) => {
+journey('browser with request', ({ params, request }) => {
   step('go to test page', async () => {
-    const resp = await apiContext.get(params.url);
+    const resp = await request.get(params.url);
     expect((await resp.body()).toString()).toMatch(/Synthetics/);
   });
 });

--- a/__tests__/fixtures/example.journey.ts
+++ b/__tests__/fixtures/example.journey.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { journey, step } from '../../src/index';
+import { journey, step } from '../../';
 
 journey('example journey', ({ page, params }) => {
   step('go to test page', async () => {

--- a/__tests__/fixtures/params-error.journey.ts
+++ b/__tests__/fixtures/params-error.journey.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { journey, step, before } from '../../src';
+import { journey, step, before } from '../../';
 
 journey('journey 1', ({}) => {
   before(({ params }) => {

--- a/__tests__/fixtures/pwoptions.journey.ts
+++ b/__tests__/fixtures/pwoptions.journey.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { journey, step, expect } from '../../dist';
+import { journey, step, expect } from '../../';
 
 journey('launch with viewport', ({ page }) => {
   step('Ensure viewport width', () => {

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -24,7 +24,7 @@
  */
 
 import { devices } from 'playwright-chromium';
-import type { SyntheticsConfig } from '../../src';
+import type { SyntheticsConfig } from '../..';
 
 module.exports = env => {
   const config: SyntheticsConfig = {

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -278,4 +278,18 @@ describe('network', () => {
       expect(timing.total).toBeLessThan(50);
     });
   });
+
+  it("doesn't capture network info from request context", async () => {
+    const driver = await Gatherer.setupDriver({
+      wsEndpoint,
+    });
+    const network = new NetworkManager(driver);
+    await network.start();
+
+    await driver.request.get(server.TEST_PAGE);
+    const netinfo = await network.stop();
+    expect(netinfo.length).toBe(0);
+    await Gatherer.dispose(driver);
+    await Gatherer.stop();
+  });
 });

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -63,7 +63,7 @@ export type Driver = {
   context: ChromiumBrowserContext;
   page: Page;
   client: CDPSession;
-  apiContext: APIRequestContext;
+  request: APIRequestContext;
 };
 
 export type TraceOutput = {

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -27,7 +27,7 @@ import {
   chromium,
   ChromiumBrowser,
   BrowserContext,
-  request,
+  request as apiRequest,
 } from 'playwright-chromium';
 import { PluginManager } from '../plugins';
 import { log } from './logger';
@@ -66,8 +66,8 @@ export class Gatherer {
 
     const page = await context.newPage();
     const client = await context.newCDPSession(page);
-    const apiContext = await request.newContext();
-    return { browser: Gatherer.browser, context, page, client, apiContext };
+    const request = await apiRequest.newContext({ ...playwrightOptions });
+    return { browser: Gatherer.browser, context, page, client, request };
   }
 
   static async getUserAgent(userAgent?: string) {
@@ -120,6 +120,7 @@ export class Gatherer {
   }
 
   static async dispose(driver: Driver) {
+    await driver.request.dispose();
     await driver.context.close();
   }
 

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -49,7 +49,7 @@ export type JourneyCallback = (options: {
   browser: Browser;
   client: CDPSession;
   params: Params;
-  apiContext: APIRequestContext;
+  request: APIRequestContext;
 }) => void;
 
 export class Journey {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export type {
   ChromiumBrowser,
   ChromiumBrowserContext,
   CDPSession,
+  APIRequestContext,
 } from 'playwright-chromium';
 
 /**

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -93,10 +93,10 @@ const loadInlineScript = source => {
     'browser',
     'params',
     'expect',
-    'apiContext',
+    'request',
     source
   );
-  journey('inline', ({ page, context, browser, params, apiContext }) => {
+  journey('inline', ({ page, context, browser, params, request }) => {
     scriptFn.apply(null, [
       step,
       page,
@@ -104,7 +104,7 @@ const loadInlineScript = source => {
       browser,
       params,
       expect,
-      apiContext,
+      request,
     ]);
   });
 };


### PR DESCRIPTION
+ Replaces the `apiContext` with `request` to keep in sync with Playwright fixture. 
+ Disposes the Request context for every journey invocation to provide isolation like how we do the Browser context isolation. 
+ Adds a test where the tracing wont work for the requests starting from these request contexts. 
+ Shares the context information with the Browser context which can be passed via Synthetics config `PlaywrightOptions` or via CLI flags. 